### PR TITLE
Changed version numbering and added dependency tree workflow

### DIFF
--- a/.github/workflows/print_dependencies.yml
+++ b/.github/workflows/print_dependencies.yml
@@ -1,0 +1,34 @@
+name: Print Dependency Tree
+
+permissions:
+  contents: read
+
+# this should only be triggered manually
+on: workflow_dispatch
+
+jobs:
+  build:
+    # run on windows to mimic local build
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        # checkout action hash for version 6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Java
+        # setup-java action hash for version 5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          # Gradle needs java 17 or above
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Print dependency tree with Gradle wrapper command
+        # this will print the dependency tree with the wrapper already provided in the repository
+        run: ./gradlew.bat dependencies
+        # these are the credentials we will need
+        env:
+            GITHUB_ACTOR: ${{ secrets.PACKAGES_USER }}
+            GITHUB_TOKEN: ${{ secrets.PACKAGES_PAT }}
+            NEXUS_USER: ${{ secrets.NEXUS_USER }}
+            NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}

--- a/buildSrc/src/main/groovy/wtmp.versioning-conventions.gradle
+++ b/buildSrc/src/main/groovy/wtmp.versioning-conventions.gradle
@@ -8,8 +8,8 @@ plugins {
 }
 
 def getConventionVersion() {
-    def fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd") // format: YYYY-MM-DD
-    return "v" + LocalDate.now().format(fmt)
+    def fmt = DateTimeFormatter.ofPattern("yyyy.MM.dd") // format: YYYY-MM-DD
+    return LocalDate.now().format(fmt)
 }
 
 tasks.register("showGit") {


### PR DESCRIPTION
Switched the version number from vYYYY-MM-DD-win-x86_64 to YYYY.MM.DD-win-x86_64 to match the other repos better. Ive updated this change in the documentation as well.

I also created a GitHub Actions workflow that just prints out the dependency tree for the repo. This is for addendum B. Ill add to the documentation now.