### PR TITLE
Split up and updated version numbers for new WAT version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,11 @@
 [versions]
-wat = { strictly = "1.1.0.34-beta-win-x86_64" }
+wat = { strictly = "1.1.0.0-win-x86_64" }
 
 # wat plugins
-usbr-plugin = "2026.03.25"
+usbr-action-panel = "2026.05.01"
+usbr-comparison-report = "2026.05.01"
+usbr-forecast-report = "2026.05.01"
+usbr-simulation-report = "2026.05.01"
 usbr-python = "2026.04.07"
 usbr-jasper = "2026.03.25"
 cequal-plugin = { strictly = "3.0.2" }
@@ -41,10 +44,10 @@ jarhdf5 = { strictly = "2.11.0" }
 
 [libraries]
 # usbr plugins
-actionpanel-plugin = { module = "usbr.wat.plugins:usbr-actionpanel-plugin", version.ref = "usbr-plugin" }
-comparison-report-plugin = { module = "usbr.wat.plugins:usbr-comparison-report", version.ref = "usbr-plugin" }
-simulation-report-plugin = { module = "usbr.wat.plugins:usbr-simulation-report", version.ref = "usbr-plugin" }
-forecast-report-plugin = {module = "usbr.wat.plugins:usbr-forecast-report", version.ref = "usbr-plugin"}
+actionpanel-plugin = { module = "usbr.wat.plugins:usbr-actionpanel-plugin", version.ref = "usbr-action-panel" }
+comparison-report-plugin = { module = "usbr.wat.plugins:usbr-comparison-report", version.ref = "usbr-comparison-report" }
+simulation-report-plugin = { module = "usbr.wat.plugins:usbr-simulation-report", version.ref = "usbr-simulation-report" }
+forecast-report-plugin = {module = "usbr.wat.plugins:usbr-forecast-report", version.ref = "usbr-forecast-report"}
 
 cequalw2-v5-tcd = { module = "edu.pdx.ce.w2:w2", version = "v5-tcd-2025-09-26"}
 


### PR DESCRIPTION
Previously all of the custom WTMP pieces shared a version number since they used to share a repository. This wasn't an issue until now since things were updated at the same time, but it is best for each repository to have a version number.

Now each repo has a separate version number. Also, WAT version number and other repository version number have been updated to account for the new WAT version.

This built successfully on my fork, but I will do more testing once merged in.