### PR TITLE
removed the exe classifiers for the w2 executables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,63 +60,53 @@ dependencies {
 
     w2_pre_exe(libs.w2.pre) {
         artifact {
-            classifier = "exe"
             extension  = "exe"
         }
     }
     w2_post_exe(libs.w2.post) {
         artifact {
-            classifier = "exe"
             extension  = "exe"
         }
     }
     cequalw2_exe(libs.cequalw2) {
         artifact {
-            classifier = "exe"
             extension  = "exe"
         }
     }
     cequalw2_TCD_exe(libs.cequalw2.tcd) {
         artifact {
-            classifier = "exe"
             extension  = "exe"
         }
     }
     cequalw2_TCD_0817_exe(libs.cequalw2.tcd0817) {
         artifact {
-            classifier = "exe"
             extension  = "exe"
         }
     }
     cequalw2_TCD_v5_exe(libs.cequalw2.v5.tcd) {
         artifact {
-            classifier = "exe"
             extension  = "exe"
         }
     }
 
     cequalw2_45_exes(libs.cequalw2.v45) {
         artifact {
-            classifier = "exe"
             extension  = "exe"
         }
     }
     cequalw2_45_exes(libs.cequalw2preconsole.v45) {
         artifact {
-            classifier = "exe"
             extension  = "exe"
         }
     }
     cequalw2_45_exes(libs.cequalw2pre.v45) {
         artifact {
-            classifier = "exe"
             extension  = "exe"
         }
     }
 
     cequalw2_folsom_exe(libs.cequalw2.folsom) {
         artifact {
-            classifier = "exe"
             extension  = "exe"
         }
     }


### PR DESCRIPTION
This goes with DOI-BOR/WTMP-W2-Executables#2 to fix the naming of executables. This change makes it so Gradle is not looking for something ending in exe.exe but instead just .exe. This will fix AT not being able to find certain W2 executables. Tested this on my fork and it worked.